### PR TITLE
add missing libcurl4 runtime dependency

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -99,6 +99,7 @@ FROM ubuntu:18.04
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
     apt-get install -qq -y --no-install-recommends \
+      libcurl4 \
       libssl-dev \
       gpg \
       gpg-agent \


### PR DESCRIPTION
without this I get:
```
docker run ghcr.io/wtsi-npg/samtools htsfile -v gs://sanger-REDACTED.vcf.gz
[W::load_plugin] can't load plugin "/usr/local/libexec/htslib/hfile_libcurl.so": libcurl.so.4: cannot open shared object file: No such file or directory
```
and
```
docker run ghcr.io/wtsi-npg/samtools ldd /usr/local/libexec/htslib/hfile_libcurl.so | grep not
        libcurl.so.4 => not found
```