### PR TITLE
expose seq_cache_populate.pl as executable

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -104,6 +104,7 @@ RUN apt-get update && \
       gnuplot \
       gpg \
       gpg-agent \
+      perl \
       locales && \
       locale-gen en_GB en_GB.UTF-8 && \
       localedef -i en_GB -c -f UTF-8 -A /usr/share/locale/locale.alias en_GB.UTF-8
@@ -112,6 +113,7 @@ RUN apt-get update && \
 COPY --from=samtools_build /usr/local/bin/plot-ampliconstats /usr/local/bin/plot-ampliconstats
 COPY --from=samtools_build /usr/local/bin/plot-bamstats /usr/local/bin/plot-bamstats
 COPY --from=samtools_build /usr/local/bin/samtools /usr/local/bin/samtools
+COPY --from=samtools_build /usr/local/bin/seq_cache_populate.pl /usr/local/bin/seq_cache_populate.pl
 COPY --from=samtools_build /usr/local/bin/bcftools /usr/local/bin/bcftools
 COPY --from=samtools_build /usr/local/bin/htsfile /usr/local/bin/htsfile
 COPY --from=samtools_build /usr/local/bin/tabix /usr/local/bin/tabix

--- a/docker/manifest.txt
+++ b/docker/manifest.txt
@@ -2,5 +2,6 @@ bcftools
 plot-ampliconstats
 plot-bamstats
 samtools
+seq_cache_populate.pl
 htsfile
 tabix


### PR DESCRIPTION
The change requires perl and dependencies to be available in later layers of the image. We therefore need to copy more files from /usr/lib and /usr/share/perl.

It does not feel right to copy the whole content of `/usr/lib`. perl is organised under `/usr/lib/x86_64-linux-gnu/perl/...` and using the specific perl version as part of the path. So looks easy to break. Doing the copy of `/usr/lib/x86_64-linux-gnu/perl` looks like a reasonable compromise.

Calling `seq_cache_populate.pl` from within the container shows the expected help message. But not easy to test without using it with some data.