### PR TITLE
add liburi-perl to final image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -96,6 +96,7 @@ FROM ubuntu:18.04
 ARG IRODS_VERSION
 ARG DEFLATE_VERSION
 
+# liburi-perl - is required for plot-bamstats
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
     apt-get install -qq -y --no-install-recommends \
@@ -103,6 +104,7 @@ RUN apt-get update && \
       curl \
       libcurl4 \
       libssl-dev \
+      liburi-perl \
       lsb-release \
       gnuplot \
       gpg \


### PR DESCRIPTION
To address #65. Install required perl libraries

```
$ singularity run docker://ghcr.io/jmtcsngr/samtools:1.9.1-alpha.3 /bin/bash
INFO:    Using cached SIF image
Singularity> /usr/local/bin/plot-bamstats -h
About: Parses output of samtools stats (former bamcheck) and calls gnuplot to create graphs.
Usage: plot-bamstats [OPTIONS] file.bam.bc
       plot-bamstats -p outdir/ file.bam.bc
Options:
   -k, --keep-files                    Do not remove temporary files.
   -l, --log-y                         Set the Y axis scale of the Insert Size plot to log 10.
   -m, --merge                         Merge multiple bamstats files and output to STDOUT.
   -p, --prefix <path>                 The output files prefix, add a slash to create new directory.
   -r, --ref-stats <file.fa.gc>        Optional reference stats file with expected GC content (created with -s).
   -s, --do-ref-stats <file.fa>        Calculate reference sequence GC for later use with -r
   -t, --targets <file.tab>            Restrict -s to the listed regions (tab-delimited chr,from,to. 1-based, inclusive)
   -q, --alt-qual-avg-method           Calculate average base quality using average base error probabilities rather than average quality scores.
   -h, -?, --help                      This help message.

Singularity>
```